### PR TITLE
Adding decimal column type support and fixed bigint, mediumtext and longtext

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Currently **not supported**:
 
 * Column types:
   * [ ] `float`
-  * [ ] `decimal`
   * [ ] `time`
   * [ ] `binary`
   * [ ] `boolean`

--- a/mysql2phinx.php
+++ b/mysql2phinx.php
@@ -160,6 +160,9 @@ function getPhinxColumnType($columndata)
         case 'datetime':
             return 'datetime';
 
+        case 'decimal':
+            return 'decimal';
+
         case 'enum':
             return 'enum';
 
@@ -242,9 +245,17 @@ function getPhinxColumnAttibutes($phinxtype, $columndata)
     }
 
     // unsigned
-    $pattern = '/\(\d+\) unsigned$/';
+    $pattern = '/\(\d+(\s*,\s*\d+)?\) unsigned$/';
     if (1 === preg_match($pattern, $columndata['Type'], $match)) {
         $attributes[] = '\'signed\' => false';
+    }
+
+    // decimal values
+    if ($phinxtype === 'decimal'
+        && 1 === preg_match('/decimal\((\d+)\s*,\s*(\d+)\)/i', $columndata['Type'], $decimalMatch)
+    ) {
+        $attributes[] = '\'precision\' => ' . (int) $decimalMatch[1];
+        $attributes[] = '\'scale\' => ' . (int) $decimalMatch[2];
     }
 
     // enum values

--- a/mysql2phinx.php
+++ b/mysql2phinx.php
@@ -148,6 +148,7 @@ function getPhinxColumnType($columndata)
         case 'smallint':
         case 'int':
         case 'mediumint':
+        case 'bigint':
             return 'integer';
 
         case 'timestamp':

--- a/mysql2phinx.php
+++ b/mysql2phinx.php
@@ -171,6 +171,8 @@ function getPhinxColumnType($columndata)
 
         case 'text':
         case 'tinytext':
+        case 'mediumtext':
+        case 'longtext':
             return 'text';
 
         case 'varchar':

--- a/mysql2phinx.php
+++ b/mysql2phinx.php
@@ -22,8 +22,8 @@ $config = array(
     'name'    => $argv[1],
     'user'    => $argv[2],
     'pass'    => $argv[3],
-    'host'    => $argc === 5 ? $argv[6] : 'localhost',
-    'port'    => $argc === 6 ? $argv[5] : '3306'
+    'host'    => $argc >= 5 ? $argv[4] : 'localhost',
+    'port'    => $argc >= 6 ? $argv[5] : '3306'
 );
 
 function createMigration($mysqli, $indent = 2)


### PR DESCRIPTION
Added support for decimal column type. Tested this with all my current decimal column types with precision, scale and unsigned.

Found and fixed a bug with bigint columns getting MysqlAdapter::INT_BIG but not type integer, instead got [bigint].
Found and fixed the same kind of bug with mediumtext and longtext. They got the right MysqlAdapter constant but not the corrent column type.

Noticed host and port parameters looked to be handled incorrectly so tweaked that a bit.